### PR TITLE
Substitute values in the example output of documentation

### DIFF
--- a/src/main/groovy/app/FuckOffService.groovy
+++ b/src/main/groovy/app/FuckOffService.groovy
@@ -15,7 +15,9 @@ class FuckOffService {
     messages.each {k,v->Eval.x m,"x.$k='${v.replaceAll("'", "\\\\'")}'"}
     m.fuckOff.each { String key, Map value ->
       def (msg, subtitle, uri) = destructure(key, value)
-      this.foaasResources."$key" = [uri, msg, subtitle, render(uri, EXAMPLE_PARAMS), [msg, subtitle] as FuckOff] as FuckOffApiResource
+      def exampleFuckOff = new FuckOff(render (msg, EXAMPLE_PARAMS), render (subtitle, EXAMPLE_PARAMS))
+      def exampleUri = render(uri, EXAMPLE_PARAMS)
+      this.foaasResources."$key" = [uri, msg, subtitle, exampleUri, exampleFuckOff] as FuckOffApiResource
     }
   }
 


### PR DESCRIPTION
The documentation substituted the params in the uri, but not in the example response.

Before:

![image](https://cloud.githubusercontent.com/assets/193047/17781678/2c73935a-6525-11e6-9b4a-7520bd55d15e.png)

After:

![image](https://cloud.githubusercontent.com/assets/193047/17781696/35e834cc-6525-11e6-80f7-6c8ad7613414.png)
